### PR TITLE
updates readme and details dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Add this line to your application JavaScript manifest:
 
     //= require scrivito_pdf_widget
 
+Note: this must be inserted below `//= require scrivito` in your manifest.
+
 ## Localization
 
 The following code represents the default localization for English. Copy it to your `en.yml` and change it if necessary:

--- a/app/views/pdf/details.html.erb
+++ b/app/views/pdf/details.html.erb
@@ -1,5 +1,5 @@
 <div class="aler alert-info">
-  This attribute are used as meta information for semantic web. It is based on <a href="http://schema.org/MediaObject">http://schema.org/MediaObject</a>.
+  This attribute is used as meta information for semantic web. It is based on <a href="http://schema.org/MediaObject">http://schema.org/MediaObject</a>.
 </div>
 
 <%= scrivito_details_for t('scrivito_pdf_widget.details.description', default: 'Description') do %>


### PR DESCRIPTION
Found a typo in the details dialog and added a note to the readme as errors occur if JavaScript manifest order is incorrect.